### PR TITLE
Add tab control and example

### DIFF
--- a/examples/uil_tabs.html
+++ b/examples/uil_tabs.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>UIL Tabs Example</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+        <link rel="shortcut icon" href="./assets/favicon.ico">
+    </head>
+<style>
+html{ overflow:hidden; width:100%; height:100%; }
+body { font-family: "Lucida Console", Monaco, monospace; background-color:#282f35; font-size:11px; color:#fff; margin: 0px; }
+
+</style>
+
+</head>
+
+<body>
+
+<div id='content'></div>
+
+<script type="module">
+
+
+    import * as UIL from '../build/uil.module.js';
+
+    let ui;
+
+    const params = {
+        masterVolume:0.7,
+        musicVolume:0.5,
+        effectsVolume:0.6,
+        musicMute:false,
+        themeColor:'#ff8844',
+        accentColor:'#44aaff',
+        bloom:1.2,
+        exposure:0.85,
+        toneMapping:'ACES',
+        resolution:'1440p',
+        fpsLimit:120,
+        networkMode:'Online',
+        region:'EU',
+        maxPlayers:8,
+        latencyWarning:80,
+        voiceChat:true
+    };
+
+    function initGUI () {
+
+        ui = new UIL.Gui({ w:320, isCanvas:false, addDOMEventListeners:true });
+
+        const audioTab = ui.add('tab', { name:'Audio', bg:'#446666' });
+        audioTab.add(params, 'masterVolume', { type:'slide', min:0, max:1, step:0.01, displayName:'Master Volume' });
+        audioTab.add(params, 'musicVolume', { type:'slide', min:0, max:1, step:0.01, displayName:'Music Volume' });
+        audioTab.add(params, 'effectsVolume', { type:'slide', min:0, max:1, step:0.01, displayName:'Effects Volume' });
+        audioTab.add(params, 'musicMute', { type:'bool', displayName:'Mute Music' });
+
+        const visualTab = ui.add('tab', { name:'Visuals', bg:'#664466' });
+        visualTab.add(params, 'themeColor', { type:'color', displayName:'Theme Color' });
+        visualTab.add(params, 'accentColor', { type:'color', displayName:'Accent Color' });
+        visualTab.add(params, 'bloom', { type:'slide', min:0, max:2, step:0.01, displayName:'Bloom' });
+        visualTab.add(params, 'exposure', { type:'slide', min:0, max:2, step:0.01, displayName:'Exposure' });
+        visualTab.add(params, 'toneMapping', { type:'list', list:['ACES','Filmic','Neutral'], displayName:'Tone Mapping' });
+        visualTab.add(params, 'resolution', { type:'list', list:['1080p','1440p','4K'], displayName:'Resolution' });
+        visualTab.add(params, 'fpsLimit', { type:'list', list:['60','120','240'], displayName:'FPS Limit' });
+
+        const networkTab = ui.add('tab', { name:'Network', bg:'#666644' });
+        networkTab.add(params, 'networkMode', { type:'list', list:['Offline','Online','LAN'], displayName:'Mode' });
+        networkTab.add(params, 'region', { type:'list', list:['NA','EU','AS','SA'], displayName:'Region' });
+        networkTab.add(params, 'maxPlayers', { type:'numeric', min:1, max:16, step:1, displayName:'Max Players' });
+        networkTab.add(params, 'latencyWarning', { type:'slide', min:0, max:200, step:1, displayName:'Latency Warning (ms)' });
+        networkTab.add(params, 'voiceChat', { type:'bool', displayName:'Voice Chat' });
+
+    }
+
+    initGUI();
+
+
+</script>
+</body>
+</html>

--- a/src/core/Gui.js
+++ b/src/core/Gui.js
@@ -98,6 +98,11 @@ export class Gui {
 
     this.isNewTarget = false;
 
+    this.tabs = [];
+    this.tabBar = null;
+    this.activeTab = null;
+    this.tabHeight = 0;
+
     let cc = this.colors;
 
     this.content = Tools.dom(
@@ -435,6 +440,104 @@ export class Gui {
   }
 
   // ----------------------
+  //   TABS MANAGEMENT
+  // ----------------------
+
+  registerTab(tab) {
+    if (!tab) return;
+
+    if (!this.tabBar) {
+      const cc = this.colors;
+      this.tabBar = document.createElement('div');
+      this.tabBar.className = 'uil-tab-bar';
+      this.tabBar.style.position = 'absolute';
+      this.tabBar.style.left = '0px';
+      this.tabBar.style.top = '0px';
+      this.tabBar.style.width = '100%';
+      this.tabBar.style.display = 'flex';
+      this.tabBar.style.flexWrap = 'wrap';
+      this.tabBar.style.alignItems = 'flex-end';
+      this.tabBar.style.gap = cc.sx + 'px';
+      this.tabBar.style.padding = cc.sy + 'px ' + cc.sx + 'px';
+      this.tabBar.style.paddingBottom = cc.sy + 'px';
+      this.tabBar.style.boxSizing = 'border-box';
+      this.tabBar.style.background = cc.background;
+      this.tabBar.style.pointerEvents = 'auto';
+      this.tabBar.style.zIndex = 1;
+
+      this.innerContent.insertBefore(this.tabBar, this.inner);
+    }
+
+    if (this.tabs.indexOf(tab) === -1) this.tabs.push(tab);
+
+    if (tab.tabButton && tab.tabButton.parentNode !== this.tabBar) {
+      this.tabBar.appendChild(tab.tabButton);
+    }
+
+    if (!this.activeTab) {
+      this.activateTab(tab);
+    } else {
+      tab.deactivate();
+      this.updateTabLayout();
+    }
+  }
+
+  unregisterTab(tab) {
+    if (!tab) return;
+
+    let id = this.tabs.indexOf(tab);
+    if (id !== -1) this.tabs.splice(id, 1);
+
+    if (this.tabBar && tab.tabButton && tab.tabButton.parentNode === this.tabBar) {
+      this.tabBar.removeChild(tab.tabButton);
+    }
+
+    if (this.activeTab === tab) {
+      this.activeTab = null;
+      if (this.tabs.length) this.activateTab(this.tabs[0]);
+    }
+
+    if (!this.tabs.length) {
+      if (this.tabBar && this.tabBar.parentNode === this.innerContent) {
+        this.innerContent.removeChild(this.tabBar);
+      }
+      this.tabBar = null;
+      this.tabHeight = 0;
+      this.inner.style.top = '0px';
+      this.calc();
+      Roots.forceZone = true;
+      return;
+    }
+
+    this.updateTabLayout();
+  }
+
+  activateTab(tab) {
+    if (!tab) return;
+    if (this.activeTab === tab) return;
+
+    if (this.activeTab) this.activeTab.deactivate();
+
+    this.activeTab = tab;
+    this.activeTab.activate();
+    this.updateTabLayout();
+  }
+
+  updateTabLayout() {
+    if (!this.tabBar) {
+      this.tabHeight = 0;
+      this.inner.style.top = '0px';
+      return;
+    }
+
+    const height = this.tabBar.offsetHeight || 0;
+    this.tabHeight = height;
+    this.inner.style.top = this.tabHeight + 'px';
+    this.calc();
+    Roots.forceZone = true;
+  }
+
+  // ----------------------
   //   TARGET
   // ----------------------
 
@@ -764,7 +867,10 @@ export class Gui {
   // ----------------------
 
   calcUis() {
-    return Roots.calcUis(this.uis, this.zone, this.zone.y);
+    const offset = this.tabHeight || 0;
+    const py = this.zone.y + offset;
+    const h = Roots.calcUis(this.uis, this.zone, py);
+    return h + offset;
   }
 
   calc() {

--- a/src/core/add.js
+++ b/src/core/add.js
@@ -22,6 +22,7 @@ import { Grid } from '../proto/Grid.js';
 import { Pad2D } from '../proto/Pad2D.js';
 import { Roots } from './Roots.js';
 import { TreeList } from '../proto/TreeList.js';
+import { Tab } from '../proto/Tab.js';
 
 export const add = function () {
 
@@ -52,7 +53,7 @@ export const add = function () {
 
         let name = type.toLowerCase();
 
-        if( name === 'group' ){ 
+        if( name === 'group' || name === 'tab' ){
             o.add = add;
             //o.dx = 8
         }
@@ -81,6 +82,7 @@ export const add = function () {
             case 'grid': n = new Grid(o); break;
             case 'pad2d': case 'pad': n = new Pad2D(o); break;
             case 'treelist': n = new TreeList(o); break;
+            case 'tab': n = new Tab(o); break;
 
         }
 

--- a/src/proto/Tab.js
+++ b/src/proto/Tab.js
@@ -1,0 +1,311 @@
+import { Proto } from '../core/Proto.js';
+import { Roots } from '../core/Roots.js';
+
+export class Tab extends Proto {
+
+    constructor( o = {} ) {
+
+        o.simple = true;
+        super( o );
+
+        this.isGroup = true;
+        this.isTab = true;
+
+        this.ADD = o.add;
+
+        this.autoHeight = true;
+        this.uis = [];
+        this.proto = null;
+        this.current = -1;
+        this.isActive = false;
+        this.tabBg = o.bg !== undefined ? o.bg : null;
+
+        this.defaultMargin = this.margin;
+        this.margin = 0;
+
+        this.useFlex = true;
+        let flexible = this.useFlex ? 'display:flex; flex-flow: row wrap;' : '';
+
+        this.bodyDisplay = this.useFlex ? 'flex' : 'block';
+
+        this.c[1] = this.dom( 'div', this.css.basic + flexible + 'width:100%; left:0; top:0;');
+
+        this.init();
+
+        this.baseDisplay = this.s[0].display;
+
+        this.s[0].background = 'none';
+        this.s[0].border = 'none';
+        this.s[0].height = '0px';
+        this.s[0].padding = '0px';
+        this.s[0].overflow = 'hidden';
+        this.s[0].pointerEvents = 'none';
+        this.s[0].display = 'none';
+
+        this.s[1] = this.c[1].style;
+        this.s[1].display = 'none';
+        this.s[1].top = '0px';
+        this.s[1].pointerEvents = 'none';
+
+        this.createTabButton();
+
+        if( this.tabBg ) this.setBG( this.tabBg );
+
+        this.main.registerTab( this );
+
+    }
+
+    createTabButton () {
+
+        const cc = this.colors;
+
+        this.tabButton = document.createElement('div');
+        this.tabButton.className = 'uil-tab-button';
+        this.tabButton.style.display = 'flex';
+        this.tabButton.style.alignItems = 'center';
+        this.tabButton.style.justifyContent = 'center';
+        this.tabButton.style.cursor = 'pointer';
+        this.tabButton.style.padding = '0 ' + (cc.sx * 2) + 'px';
+        this.tabButton.style.height = this.main.size.h + 'px';
+        this.tabButton.style.border = cc.borderSize + 'px solid ' + cc.border;
+        this.tabButton.style.borderRadius = this.radius + 'px';
+        this.tabButton.style.background = cc.button;
+        this.tabButton.style.color = cc.text;
+        this.tabButton.style.fontFamily = cc.fontFamily;
+        this.tabButton.style.fontSize = cc.fontSize + 'px';
+        this.tabButton.style.fontWeight = cc.fontWeight;
+        this.tabButton.style.textShadow = cc.fontShadow;
+        this.tabButton.style.pointerEvents = 'auto';
+        this.tabButton.style.marginRight = cc.sx + 'px';
+        this.tabButton.textContent = this.txt;
+
+        this.tabButton.addEventListener( 'click', ( e ) => {
+            e.preventDefault();
+            this.main.activateTab( this );
+        });
+
+        this.updateButtonState();
+
+    }
+
+    updateButtonState () {
+
+        if( !this.tabButton ) return;
+
+        const cc = this.colors;
+        if( this.isActive ){
+            this.tabButton.style.background = cc.select;
+            this.tabButton.style.color = cc.textSelect;
+            this.tabButton.style.borderColor = cc.select;
+        } else {
+            this.tabButton.style.background = cc.button;
+            this.tabButton.style.color = cc.text;
+            this.tabButton.style.borderColor = cc.border;
+        }
+
+    }
+
+    setBG ( bg ) {
+
+        if( bg !== undefined ) this.tabBg = bg;
+        if( !this.isActive ) return;
+
+        this.s[0].background = this.tabBg ? this.tabBg : 'none';
+        this.s[1].background = this.tabBg ? this.tabBg : 'none';
+
+    }
+
+    testZone () {
+
+        if( !this.isActive ) return '';
+        let l = this.local;
+        if( l.x === -1 && l.y === -1 ) return '';
+        return 'content';
+
+    }
+
+    clearTarget () {
+
+        if( this.current === -1 ) return false;
+        if( this.proto && this.proto.s ){
+            this.proto.uiout();
+            this.proto.reset();
+        }
+        this.proto = null;
+        this.current = -1;
+        this.cursor();
+        return true;
+
+    }
+
+    reset () {
+
+        this.clearTarget();
+
+    }
+
+    handleEvent ( e ) {
+
+        if( !this.isActive ) return false;
+
+        let type = e.type;
+        let change = false;
+        let protoChange = false;
+
+        let name = this.testZone( e );
+        if( !name ) return false;
+
+        switch( name ){
+
+            case 'content':
+                if( Roots.isMobile && type === 'mousedown' ) this.getNext( e, change );
+                if( this.proto ) protoChange = this.proto.handleEvent( e );
+                if( !Roots.lock ) this.getNext( e, change );
+            break;
+
+        }
+
+        if( this.isDown ) change = true;
+        if( protoChange ) change = true;
+
+        return change;
+
+    }
+
+    getNext ( e, change ) {
+
+        let next = Roots.findTarget( this.uis, e );
+
+        if( next !== this.current ){
+            this.clearTarget();
+            this.current = next;
+            change = true;
+        }
+
+        if( next !== -1 ){
+            this.proto = this.uis[ this.current ];
+            this.proto.uiover();
+        }
+
+    }
+
+    add () {
+
+        let a = arguments;
+
+        if( typeof a[1] === 'object' ){
+            a[1].isUI = this.isUI;
+            a[1].target = this.c[1];
+            a[1].main = this.main;
+            a[1].group = this;
+        } else if( typeof a[1] === 'string' ){
+            if( a[2] === undefined ) [].push.call( a, { isUI:true, target:this.c[1], main:this.main, group:this });
+            else{
+                a[2].isUI = true;
+                a[2].target = this.c[1];
+                a[2].main = this.main;
+                a[2].group = this;
+            }
+        }
+
+        let u = this.ADD.apply( this, a );
+
+        if( u === null ) return u;
+
+        if( u.isGroup ) u.dx = 8;
+
+        Roots.forceZone = true;
+
+        this.uis.push( u );
+
+        if( this.isActive ) this.main.calc();
+
+        return u;
+
+    }
+
+    calcUis () {
+
+        if( !this.isActive || this.uis.length === 0 ){
+            this.h = 0;
+            this.s[0].height = '0px';
+            this.zone.h = this.margin;
+            return;
+        }
+
+        this.h = Roots.calcUis( this.uis, this.zone, this.zone.y, true );
+        this.s[0].height = this.h + 'px';
+        this.zone.h = this.h + this.margin;
+
+    }
+
+    activate () {
+
+        if( this.isActive ) return;
+        this.isActive = true;
+        this.margin = this.defaultMargin;
+        this.s[0].display = this.baseDisplay;
+        this.s[0].pointerEvents = 'auto';
+        this.s[1].display = this.bodyDisplay;
+        this.s[1].pointerEvents = 'auto';
+        this.updateButtonState();
+        if( this.tabBg ) this.setBG();
+        this.calcUis();
+        Roots.needResize = true;
+        Roots.forceZone = true;
+
+    }
+
+    deactivate () {
+
+        if( !this.isActive ) return;
+        this.clearTarget();
+        this.isActive = false;
+        this.margin = 0;
+        this.h = 0;
+        this.zone.h = 0;
+        this.s[0].height = '0px';
+        this.s[0].display = 'none';
+        this.s[0].pointerEvents = 'none';
+        this.s[1].display = 'none';
+        this.s[1].pointerEvents = 'none';
+        this.updateButtonState();
+        Roots.needResize = true;
+        Roots.forceZone = true;
+
+    }
+
+    dispose () {
+
+        if( this.main ) this.main.unregisterTab( this );
+        this.clear();
+        super.dispose();
+
+    }
+
+    clear () {
+
+        this.empty();
+
+    }
+
+    empty () {
+
+        let i = this.uis.length, item;
+
+        while( i-- ){
+            item = this.uis.pop();
+            if( this.c[1] && item.c ) this.c[1].removeChild( item.c[0] );
+            item.clear( true );
+        }
+
+        this.h = 0;
+        this.zone.h = 0;
+        this.margin = 0;
+
+        Roots.needResize = true;
+        Roots.forceZone = true;
+
+    }
+
+}


### PR DESCRIPTION
## Summary
- add a Tab proto component for grouping controls into selectable tabs
- integrate tab management into the GUI core and register the new control type
- create a tabs example showcasing three distinct tabbed control groups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d008bbc9e8832fa994855cb48ff087