### PR TITLE
Fix tabs metadata handling and restore example layout

### DIFF
--- a/examples/uil_tabs.html
+++ b/examples/uil_tabs.html
@@ -8,6 +8,13 @@
       content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"
     />
     <link rel="shortcut icon" href="./assets/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
     <style>
       html {
         overflow: hidden;
@@ -82,11 +89,27 @@
         parent: document.body,
       });
 
-      const tabs = ui.add("tabs", {
-        tabs: ["General", "Avanzado", "Debug"],
-        tabBg: { General: "#660000", Avanzado: "#006600", Debug: "#000066" },
-        active: 0,
-      });
+      const tabs = ui.add(
+        "tabs",
+        [
+          {
+            label: "General",
+            icon: '<i class="fa-solid fa-user"></i>',
+            background: "#660000",
+          },
+          {
+            label: "Avanzado",
+            icon: '<i class="fa-solid fa-star"></i>',
+            background: "#006600",
+          },
+          {
+            label: "Debug",
+            icon: '<i class="fa-solid fa-cog"></i>',
+            background: "#000066",
+          },
+        ],
+        0
+      );
       tabs.setHeaderHeight(30);
       // (opcional) cambiar el tab activo por código:
       // tabs.setActive(1);

--- a/src/core/add.js
+++ b/src/core/add.js
@@ -30,10 +30,36 @@ export const add = function () {
 
         let type, o, ref = false, n = null;
 
-        if( typeof a[0] === 'string' ){ 
+        if( typeof a[0] === 'string' ){
 
             type = a[0];
-            o = a[1] || {};
+
+            if( type && type.toLowerCase() === 'tabs' && Array.isArray(a[1]) ){
+
+                const tabsArray = a[1];
+                const possibleActive = a[2];
+                const possibleOptions = typeof possibleActive === 'object' ? possibleActive : (typeof a[3] === 'object' ? a[3] : null);
+                const activeIndex = typeof possibleActive === 'number' ? possibleActive : (typeof a[3] === 'number' ? a[3] : undefined);
+
+                const meta = {};
+                const metaKeys = ['isUI','main','target','group','ontop'];
+                for( let i = 0; i < metaKeys.length; i++ ){
+                    const key = metaKeys[i];
+                    if( tabsArray && tabsArray[key] !== undefined ) meta[key] = tabsArray[key];
+                }
+
+                o = Object.assign({}, meta, possibleOptions || {}, {
+                    tabs: tabsArray,
+                });
+
+                if( activeIndex !== undefined ) o.active = activeIndex;
+                else if( o.active === undefined ) o.active = 0;
+
+            } else {
+
+                o = a[1] || {};
+
+            }
 
         } else if ( typeof a[0] === 'object' ){ // like dat gui
 

--- a/src/proto/Tabs.js
+++ b/src/proto/Tabs.js
@@ -43,6 +43,7 @@ export class Tabs extends Proto {
     this._uisByPage = []; // lista de controles por tab
     this._tabEls = []; // elementos del header
     this._tabLabelEls = []; // etiquetas visibles
+    this._tabIconEls = []; // iconos visibles
     this.uis = []; // alias a la lista del tab activo (para compatibilidad)
     this.current = -1; // índice de control activo DENTRO de la lista visible
     this.proto = null;
@@ -92,25 +93,36 @@ export class Tabs extends Proto {
       const iconMarkup = this._tabIcons[i];
       const labelText = this.tabNames[i];
       const hasLabel = labelText !== undefined && labelText !== null && labelText !== "";
+
+      let iconWrap = null;
+      let labelSpan = null;
+
       if (iconMarkup) {
-        const iconWrap = document.createElement("span");
+        iconWrap = document.createElement("span");
         iconWrap.style.display = "inline-flex";
         iconWrap.style.alignItems = "center";
-        iconWrap.style.marginRight = hasLabel ? "6px" : "0";
         iconWrap.style.pointerEvents = "none";
         iconWrap.innerHTML = iconMarkup;
         t.appendChild(iconWrap);
       }
 
       if (hasLabel) {
-        const labelSpan = document.createElement("span");
+        labelSpan = document.createElement("span");
         labelSpan.textContent = labelText;
         labelSpan.style.pointerEvents = "none";
-        t.appendChild(labelSpan);
-        this._tabLabelEls.push(labelSpan);
-      } else {
-        this._tabLabelEls.push(null);
+        if (iconWrap) {
+          iconWrap.insertAdjacentElement("afterend", labelSpan);
+        } else {
+          t.appendChild(labelSpan);
+        }
       }
+
+      if (iconWrap) {
+        iconWrap.style.marginRight = labelSpan ? "6px" : "0";
+      }
+
+      this._tabLabelEls.push(labelSpan);
+      this._tabIconEls.push(iconWrap);
 
       this.c[2].appendChild(t);
       this._tabEls.push(t);

--- a/src/proto/Tabs.js
+++ b/src/proto/Tabs.js
@@ -90,21 +90,27 @@ export class Tabs extends Proto {
       );
 
       const iconMarkup = this._tabIcons[i];
+      const labelText = this.tabNames[i];
+      const hasLabel = labelText !== undefined && labelText !== null && labelText !== "";
       if (iconMarkup) {
         const iconWrap = document.createElement("span");
         iconWrap.style.display = "inline-flex";
         iconWrap.style.alignItems = "center";
-        iconWrap.style.marginRight = "6px";
+        iconWrap.style.marginRight = hasLabel ? "6px" : "0";
         iconWrap.style.pointerEvents = "none";
         iconWrap.innerHTML = iconMarkup;
         t.appendChild(iconWrap);
       }
 
-      const labelSpan = document.createElement("span");
-      labelSpan.textContent = this.tabNames[i];
-      labelSpan.style.pointerEvents = "none";
-      t.appendChild(labelSpan);
-      this._tabLabelEls.push(labelSpan);
+      if (hasLabel) {
+        const labelSpan = document.createElement("span");
+        labelSpan.textContent = labelText;
+        labelSpan.style.pointerEvents = "none";
+        t.appendChild(labelSpan);
+        this._tabLabelEls.push(labelSpan);
+      } else {
+        this._tabLabelEls.push(null);
+      }
 
       this.c[2].appendChild(t);
       this._tabEls.push(t);
@@ -580,17 +586,17 @@ export class Tabs extends Proto {
       }
 
       if (entry && typeof entry === "object") {
-        const label =
-          entry.label !== undefined
-            ? String(entry.label)
-            : entry.name !== undefined
-            ? String(entry.name)
-            : `Tab ${i + 1}`;
+        let label = null;
+        if (entry.label !== undefined) label = String(entry.label);
+        else if (entry.name !== undefined) label = String(entry.name);
         let icon = null;
         if (entry.icon !== undefined && entry.icon !== null) {
           if (typeof entry.icon === "string") icon = entry.icon;
           else if (entry.icon && typeof entry.icon === "object" && entry.icon.outerHTML) icon = entry.icon.outerHTML;
           else icon = String(entry.icon);
+        }
+        if (label === null) {
+          label = icon ? "" : `Tab ${i + 1}`;
         }
         const background =
           entry.background !== undefined

--- a/src/proto/Tabs.js
+++ b/src/proto/Tabs.js
@@ -13,8 +13,13 @@ export class Tabs extends Proto {
     this.ADD = o.add;
 
     // Lista de tabs y activo (para header + páginas)
-    this.tabNames =
-      Array.isArray(o.tabs) && o.tabs.length ? o.tabs : ["Tab 1", "Tab 2"];
+    this._tabsData = this._normalizeTabs(o.tabs);
+    this.tabNames = this._tabsData.map((tab) => tab.label);
+    this._tabIcons = this._tabsData.map((tab) => tab.icon || null);
+    const perTabBackgrounds = this._tabsData.map((tab) => {
+      const bg = tab.background;
+      return bg !== undefined && bg !== "" ? bg : null;
+    });
     this.active = Math.min(
       Math.max(0, o.active | 0 || 0),
       this.tabNames.length - 1
@@ -25,7 +30,7 @@ export class Tabs extends Proto {
     this.inactiveBg = o.inactiveBg || "#555555";
 
     // NEW: mapa de colores por tab
-    const __tabBgMap = this._buildTabBgMap(o);
+    const __tabBgMap = this._buildTabBgMap(o, perTabBackgrounds);
     this._tabBaseBg = __tabBgMap.base;    // color base (inactivo + contenido)
     this._tabActiveBg = __tabBgMap.active; // color activo aclarado para header
 
@@ -37,6 +42,7 @@ export class Tabs extends Proto {
     this._pages = []; // <div> por tab dentro de c[3]
     this._uisByPage = []; // lista de controles por tab
     this._tabEls = []; // elementos del header
+    this._tabLabelEls = []; // etiquetas visibles
     this.uis = []; // alias a la lista del tab activo (para compatibilidad)
     this.current = -1; // índice de control activo DENTRO de la lista visible
     this.proto = null;
@@ -82,7 +88,24 @@ export class Tabs extends Proto {
           // inicial: inactivo; luego _renderTabsActive() ajusta el activo
           `padding:0 10px; background:${(this._tabBaseBg[i]||this.inactiveBg)}; color:${cc.text};`
       );
-      t.textContent = this.tabNames[i];
+
+      const iconMarkup = this._tabIcons[i];
+      if (iconMarkup) {
+        const iconWrap = document.createElement("span");
+        iconWrap.style.display = "inline-flex";
+        iconWrap.style.alignItems = "center";
+        iconWrap.style.marginRight = "6px";
+        iconWrap.style.pointerEvents = "none";
+        iconWrap.innerHTML = iconMarkup;
+        t.appendChild(iconWrap);
+      }
+
+      const labelSpan = document.createElement("span");
+      labelSpan.textContent = this.tabNames[i];
+      labelSpan.style.pointerEvents = "none";
+      t.appendChild(labelSpan);
+      this._tabLabelEls.push(labelSpan);
+
       this.c[2].appendChild(t);
       this._tabEls.push(t);
     }
@@ -538,8 +561,53 @@ export class Tabs extends Proto {
     return this._makeTabHandle(i);
   }
 
-  
+
   // ---------- Colores por tab (NEW) ----------
+  _normalizeTabs(tabs) {
+    if (!Array.isArray(tabs) || tabs.length === 0) {
+      return [
+        { label: "Tab 1", icon: null, background: null },
+        { label: "Tab 2", icon: null, background: null },
+      ];
+    }
+
+    const normalized = [];
+    for (let i = 0; i < tabs.length; i++) {
+      const entry = tabs[i];
+      if (typeof entry === "string") {
+        normalized.push({ label: entry, icon: null, background: null });
+        continue;
+      }
+
+      if (entry && typeof entry === "object") {
+        const label =
+          entry.label !== undefined
+            ? String(entry.label)
+            : entry.name !== undefined
+            ? String(entry.name)
+            : `Tab ${i + 1}`;
+        let icon = null;
+        if (entry.icon !== undefined && entry.icon !== null) {
+          if (typeof entry.icon === "string") icon = entry.icon;
+          else if (entry.icon && typeof entry.icon === "object" && entry.icon.outerHTML) icon = entry.icon.outerHTML;
+          else icon = String(entry.icon);
+        }
+        const background =
+          entry.background !== undefined
+            ? entry.background
+            : entry.bg !== undefined
+            ? entry.bg
+            : null;
+        normalized.push({ label, icon, background });
+        continue;
+      }
+
+      normalized.push({ label: `Tab ${i + 1}`, icon: null, background: null });
+    }
+
+    return normalized;
+  }
+
   // Mezcla con blanco para aclarar el color activo
   _blendWithWhite(hex, alpha = 0.22) {
     const c = this._hexToRgb(hex);
@@ -564,7 +632,7 @@ export class Tabs extends Proto {
     return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
   }
 
-  _buildTabBgMap(o) {
+  _buildTabBgMap(o, perTabBackgrounds = []) {
     const names = this.tabNames || [];
     const base = new Array(names.length).fill(null);
     const active = new Array(names.length).fill(null);
@@ -577,7 +645,8 @@ export class Tabs extends Proto {
       return null;
     };
     for (let i = 0; i < names.length; i++) {
-      const c = getColorFor(i, names[i]);
+      const bgFromTab = perTabBackgrounds[i] ?? null;
+      const c = bgFromTab || getColorFor(i, names[i]);
       base[i] = c || null;
       active[i] = c ? this._blendWithWhite(c, 0.22) : null;
     }
@@ -594,6 +663,7 @@ export class Tabs extends Proto {
     if (i === -1) return false;
     this._tabBaseBg[i] = color;
     this._tabActiveBg[i] = color ? this._blendWithWhite(color, 0.22) : null;
+    if (this._tabsData && this._tabsData[i]) this._tabsData[i].background = color;
     this._renderTabsActive();
     if (i === this.active) this._applyContentBackground(i);
     return true;


### PR DESCRIPTION
## Summary
- allow `ui.add("tabs", …)` to accept an array of tab descriptors plus an optional active index
- render optional tab icons and per-tab backgrounds inside the Tabs component
- refresh the tabs example to demonstrate icons and load Font Awesome assets
- ensure the tabs helper carries GUI metadata through the descriptor-based signature so layout sizing works
- correct the Font Awesome integrity hash so icons load without being blocked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfce1b1a8c832f9fd95577dec7e80f